### PR TITLE
add 'before' trigger to Step

### DIFF
--- a/shepherd.js
+++ b/shepherd.js
@@ -1604,6 +1604,7 @@ return this.Tether;
 
     Step.prototype.show = function() {
       var _this = this;
+      this.trigger('before');
       if (this.el == null) {
         this.render();
       }


### PR DESCRIPTION
There are times when it's necessary to do something prior to the render() call in Step.show().  This adds a before trigger to Step.