### PR TITLE
Add js file to main property

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "gulp-bower": "0.0.1",
         "gulp-wrap-umd": "*"
     },
+    "main": "shepherd.js",
     "spm": {
         "main": "shepherd.js"
     }


### PR DESCRIPTION
I'm installing shepherd with NPM by listing it as a dependency in my package.json
```
"dependencies": {
"shepherd": "git://github.com/HubSpot/shepherd.git#58a37fa0263bf205fff7a64abb62216b1738e0c2",
},
```

Webpack and Browserify would require the main js file to be listed in the `main` property, instead it is listed in `spm.main`. I'm not using `spm`

For now I've decided to keep both, to not break `spm` support.