### PR TITLE
Change UTF-8 Character to escaped Unicode

### DIFF
--- a/src/js/shepherd.js
+++ b/src/js/shepherd.js
@@ -328,7 +328,7 @@ class Step extends Evented {
     }
 
     if (this.options.showCancelLink) {
-      const link = createFromHTML("<a href class='shepherd-cancel-link'>✕</a>");
+      const link = createFromHTML("<a href class='shepherd-cancel-link'>\u2715</a>");
       header.appendChild(link);
 
       this.el.className += ' shepherd-has-cancel-link';


### PR DESCRIPTION
This change prevents accidental encoding conversion errors of the cancel icon.