### PR TITLE
Add ember-shepherd to docs

### DIFF
--- a/docs/1-Examples/1-projects_using_shepherd.md
+++ b/docs/1-Examples/1-projects_using_shepherd.md
@@ -1,0 +1,11 @@
+## Projects Using Shepherd
+
+Here we showcase some of the awesome libraries built using Shepherd.
+
+### [ember-shepherd](https://github.com/shipshapecode/ember-shepherd)
+
+Ember addon for the site tour library Shepherd
+
+### Your Project Here
+
+If you have a cool open-source library built on Shepherd, PR this doc.


### PR DESCRIPTION
Adds __Projects using Shepherd__ section to documentation and adds [ember-shepherd](https://github.com/shipshapecode/ember-shepherd) to section.

Closes #101 

\cc @rwwagner90