### PR TITLE
Change `matchesSelector` to improve advanceOn functionality

### DIFF
--- a/src/js/shepherd.js
+++ b/src/js/shepherd.js
@@ -52,21 +52,7 @@ function createFromHTML (html) {
 }
 
 function matchesSelector (el, sel) {
-  let matches;
-  if (!isUndefined(el.matches)) {
-    matches = el.matches;
-  } else if (!isUndefined(el.matchesSelector)) {
-    matches = el.matchesSelector;
-  } else if (!isUndefined(el.msMatchesSelector)) {
-    matches = el.msMatchesSelector;
-  } else if (!isUndefined(el.webkitMatchesSelector)) {
-    matches = el.webkitMatchesSelector;
-  } else if (!isUndefined(el.mozMatchesSelector)) {
-    matches = el.mozMatchesSelector;
-  } else if (!isUndefined(el.oMatchesSelector)) {
-    matches = el.oMatchesSelector;
-  }
-  return matches.call(el, sel);
+  return $(sel).parent().find(el).length > 0;
 }
 
 const positionRe = /^(.+) (top|left|right|bottom|center|\[[a-z ]+\])$/


### PR DESCRIPTION
Hi! This is an awesome library and I would like to say thanks for open sourcing it! I just spent a fair bit of time debugging an issue with `advanceOn`, the problem I was facing was that my element that I was selecting for was not the element I was clicking, but either its parent or grandparent. The current logic of `matchesSelector` only checks for an exact match, when sometimes you want to select for an element or all the possible contents inside it. This fix solves that problem :) 

I'll build and make another commit if you think you'd like to accept the change upstream.